### PR TITLE
Fix typo in config comment

### DIFF
--- a/project/app/config.py
+++ b/project/app/config.py
@@ -121,7 +121,7 @@ class Config:
     JSON_AS_ASCII = False
     JSONIFY_PRETTYPRINT_REGULAR = False
 
-    # overwrite for testing develpment propose
+    # overwrite for testing development purposes
     JWT_COOKIE_SECURE = True  # development purposes
     JWT_COOKIE_CSRF_PROTECT = True  # development purposes
 


### PR DESCRIPTION
## Summary
- correct spelling error in Config comment

## Testing
- `grep -n "develp" -r . | head`


------
https://chatgpt.com/codex/tasks/task_e_68464ec16754832e9d4865147cf43734