### PR TITLE
Update README with docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ El script `make_nginx.conf.sh <dominio>` ayuda a generar la configuración de Ng
 
 ### CLI para crear módulos
 
-Puedes crear un módulo básico ejecutando:
+El script `cli/create_module.py` genera la estructura inicial de un módulo Flask. Puedes crear un módulo básico ejecutando:
 
 ```bash
 python cli/create_module.py <nombre> --api --ui
 ```
 
 Esto crea la estructura en `project/app/modules/` y deberás añadir el nombre del módulo en `app/config.py`.
+
+## Documentación
+
+La documentación se genera con `make documents` y queda disponible en [`docs/`](docs/).
 
 ## 3. Arquitectura del Software
 


### PR DESCRIPTION
## Summary
- mention how to use `cli/create_module.py`
- add new **Documentación** section

## Testing
- `make test` *(fails: cannot open venv)*

------
https://chatgpt.com/codex/tasks/task_e_68467cb04524832e9e4a6740ed14e2dd