### PR TITLE
Add optional fields to Organization

### DIFF
--- a/project/app/core/controller.py
+++ b/project/app/core/controller.py
@@ -661,6 +661,10 @@ class OrgView(MethodView):
         org = Organization(
             name=data["name"],
             description=data.get("description", ""),
+            nit=data.get("nit"),
+            contact=data.get("contact"),
+            address=data.get("address"),
+            phone=data.get("phone"),
         )
         if "reseller_id" in data:
             claims = get_jwt()
@@ -702,6 +706,14 @@ class OrgView(MethodView):
             org.name = data["name"]
         if "description" in data and data["description"] is not None:
             org.description = data["description"]
+        if "nit" in data:
+            org.nit = data["nit"]
+        if "contact" in data:
+            org.contact = data["contact"]
+        if "address" in data:
+            org.address = data["address"]
+        if "phone" in data:
+            org.phone = data["phone"]
         if "reseller_id" in data:
             claims = get_jwt()
             if claims.get("rol") == RoleEnum.ADMINISTRATOR.value:
@@ -822,6 +834,10 @@ class OrgView(MethodView):
             "id": org.id,
             "name": org.name,
             "description": org.description,
+            "nit": org.nit,
+            "contact": org.contact,
+            "address": org.address,
+            "phone": org.phone,
             "reseller_id": org.get_reseller.id if org.get_reseller else "",
             "reseller": org.get_reseller.full_name if org.get_reseller else "",
             "active": org.active,

--- a/project/app/core/models.py
+++ b/project/app/core/models.py
@@ -367,6 +367,26 @@ class Organization(db.Model):
         db.String(255),
         doc="Descripción del cliente. Proporciona información adicional sobre el cliente u organización.",
     )
+    nit = db.Column(
+        db.String(50),
+        nullable=True,
+        doc="Número de identificación tributaria de la organización (opcional).",
+    )
+    contact = db.Column(
+        db.String(100),
+        nullable=True,
+        doc="Nombre de la persona de contacto de la organización (opcional).",
+    )
+    address = db.Column(
+        db.String(150),
+        nullable=True,
+        doc="Dirección física de la organización (opcional).",
+    )
+    phone = db.Column(
+        db.String(50),
+        nullable=True,
+        doc="Número de teléfono de la organización (opcional).",
+    )
     profile_data = db.Column(
         db.JSON,
         default=dict,

--- a/project/app/core/schemas.py
+++ b/project/app/core/schemas.py
@@ -37,6 +37,10 @@ class OrganizationSchema(SQLAlchemyAutoSchema):
         lambda: ResellerPackageSchema(only=("id", "reseller", "max_clients")),
         dump_only=True,
     )
+    nit = fields.String(allow_none=True)
+    contact = fields.String(allow_none=True)
+    address = fields.String(allow_none=True)
+    phone = fields.String(allow_none=True)
 
     class Meta:
         model = Organization

--- a/project/app/core/templates/dashboard/clients.j2
+++ b/project/app/core/templates/dashboard/clients.j2
@@ -6,14 +6,36 @@
 {% set show_select_box = True %}
 
 {# Mostrar la grid de ítems #}
-{% set table_headers = ["ID", "Nombre del Cliente", "Descripción", "Reseller"] %}
-{% set item_fields = ["id", "name", "description", "reseller" ] %}
+{% set table_headers = [
+    "ID",
+    "Nombre del Cliente",
+    "Descripción",
+    "NIT",
+    "Contacto",
+    "Dirección",
+    "Teléfono",
+    "Reseller"
+] %}
+{% set item_fields = [
+    "id",
+    "name",
+    "description",
+    "nit",
+    "contact",
+    "address",
+    "phone",
+    "reseller"
+] %}
 
 
 {# formulario de editar y add #}
 {% set form_fields = {
     'name': {'type': 'text', 'label': 'Nombre del Cliente', 'required': True, 'disabled_in_edit': True},
-    'description': {'type': 'text', 'label': 'Descripción', 'required': True},
+    'description': {'type': 'text', 'label': 'Descripción', 'required': False},
+    'nit': {'type': 'text', 'label': 'NIT', 'required': False},
+    'contact': {'type': 'text', 'label': 'Contacto', 'required': False},
+    'address': {'type': 'text', 'label': 'Dirección', 'required': False},
+    'phone': {'type': 'text', 'label': 'Teléfono', 'required': False},
     'reseller_id': {'type': 'select', 'label': 'Reseller', 'options': reseller_dict, 'required': True, 'new_value': False},
 } %}
 

--- a/project/migrations/versions/b1d3f9c38b9c_add_org_optional_columns.py
+++ b/project/migrations/versions/b1d3f9c38b9c_add_org_optional_columns.py
@@ -1,0 +1,28 @@
+"""add optional fields to organization
+
+Revision ID: b1d3f9c38b9c
+Revises: 
+Create Date: 2025-06-09 07:06:59.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b1d3f9c38b9c'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('organizations', sa.Column('nit', sa.String(length=50), nullable=True))
+    op.add_column('organizations', sa.Column('contact', sa.String(length=100), nullable=True))
+    op.add_column('organizations', sa.Column('address', sa.String(length=150), nullable=True))
+    op.add_column('organizations', sa.Column('phone', sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    op.drop_column('organizations', 'phone')
+    op.drop_column('organizations', 'address')
+    op.drop_column('organizations', 'contact')
+    op.drop_column('organizations', 'nit')


### PR DESCRIPTION
## Summary
- add optional org info fields to ORM model
- expose the new fields in OrganizationSchema
- accept optional fields in org API create/update methods
- show extra client info in dashboard form and list
- create Alembic migration for the new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846879df7bc832ebc9c156832935e82