### PR TITLE
Add search + filter to foliage module

### DIFF
--- a/project/app/modules/foliage/templates/farms.j2
+++ b/project/app/modules/foliage/templates/farms.j2
@@ -17,3 +17,4 @@
 {% set api_url = url_for('foliage_api.farms_view') %}
 {% set csv_upload_url = url_for('foliage_api.upload_csv') %}
 {% set csv_download_url = url_for('foliage_api.download_csv', resource='farms') %}
+{% set search_url = url_for('foliage.amd_farms') %}

--- a/project/app/modules/foliage/templates/lots.j2
+++ b/project/app/modules/foliage/templates/lots.j2
@@ -16,4 +16,5 @@
 {# entregado desde el endpoint #}
 {# api de consumo #}
 {% set api_url = url_for('foliage_api.lots_view') %}
+{% set search_url = url_for('foliage.amd_lots') %}
 

--- a/project/app/modules/foliage/web_routes.py
+++ b/project/app/modules/foliage/web_routes.py
@@ -86,7 +86,9 @@ def amd_farms():
         "data_menu": get_dashboard_menu(),
     }
     farm_view = FarmView()
-    response = farm_view._get_farm_list()
+    filter_value = request.args.get("filter_value", type=int)
+    search = request.args.get("search")
+    response = farm_view._get_farm_list(filter_by=filter_value, search=search)
     items = response.get_json()
     status_code = response.status_code
     assigned_org = get_clients_for_user(user_id)
@@ -100,6 +102,12 @@ def amd_farms():
             org_dict=org_dict,
             **context,
             request=request,
+            filter_field="org_id",
+            filter_options=assigned_org,
+            filter_value=filter_value,
+            select_url=url_for("foliage.amd_farms"),
+            search=search,
+            search_url=url_for("foliage.amd_farms"),
         ),
         200,
     )
@@ -120,10 +128,10 @@ def amd_lots(filter_value=None):
         "data_menu": get_dashboard_menu(),
     }
     lot_view = LotView()
-    filter_value = request.args.get("filter_value")
-    if filter_value:
-        filter_value = int(filter_value)
-        response = lot_view._get_lot_list(filter_by=filter_value)
+    filter_value = request.args.get("filter_value", type=int)
+    search = request.args.get("search")
+    if filter_value or search:
+        response = lot_view._get_lot_list(filter_by=filter_value, search=search)
     else:
         response = lot_view._get_lot_list()
 
@@ -150,6 +158,8 @@ def amd_lots(filter_value=None):
             filter_options=filter_options,
             filter_value=filter_value,
             select_url=select_url,
+            search=search,
+            search_url=url_for("foliage.amd_lots"),
         ),
         200,
     )

--- a/project/app/templates/default/layouts/crud_base.j2
+++ b/project/app/templates/default/layouts/crud_base.j2
@@ -105,6 +105,23 @@ base_input_classes, table_header_class, table_cell_class %}
 {% endif %}
 {# fin Selector dinámico #}
 
+    {# Buscador genérico #}
+    {% if search_url %}
+    <div class="px-0 py-4 bg-white dark:bg-gray-900 flex flex-col sm:flex-row sm:items-end gap-3 w-full max-w-md">
+    <form action="{{ search_url }}" method="get" class="w-full flex flex-col sm:flex-row gap-3">
+        {% if filter_value %}
+            <input type="hidden" name="filter_value" value="{{ filter_value }}">
+        {% endif %}
+        <input type="text" name="search" placeholder="Buscar" value="{{ search or '' }}"
+            class="flex-grow w-full pl-4 pr-10 py-2.5 text-base border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm bg-white text-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 shadow-sm">
+        <button type="submit" class="px-5 py-2.5 rounded-lg font-medium text-sm shadow-sm transition-all duration-200 ease-in-out {{ base_button_classes }} {{ border_color }} {{ bg_color }} {{ text_color }} {{ hover_bg_color }} {{ focus_ring_color }}">
+            Buscar
+        </button>
+    </form>
+    </div>
+    {% endif %}
+    {# fin buscador genérico #}
+
         <div class="mb-4 flex flex-wrap gap-2 justify-between items-center">
             <div class="flex gap-2">
                 <button onclick="showModal('create')" class="{{ base_button_classes }} {{ border_color }} {{ bg_color }} {{ text_color }} {{ hover_bg_color }} {{ focus_ring_color }}">


### PR DESCRIPTION
## Summary
- support filtering and searching in `FarmView` and `LotView`
- expose `search` and `filter` parameters in foliage web routes
- render a search form in `crud_base` layout
- add search URL to `farms.j2` and `lots.j2`

## Testing
- `make -f project/Makefile test` *(fails: cannot open venv/bin/activate)*

------
https://chatgpt.com/codex/tasks/task_e_68468cb5fdcc832e856cedd1a422f2d8