### PR TITLE
Add foliage report data API

### DIFF
--- a/project/app/modules/foliage_report/api_routes.py
+++ b/project/app/modules/foliage_report/api_routes.py
@@ -15,6 +15,8 @@ from .helpers import ReportView
 
 report_view = ReportView.as_view("report_view")
 api.add_url_rule("/report/<int:id>", view_func=report_view, methods=["GET"])
+report_data_view = ReportView.as_view("report_data")
+api.add_url_rule("/data/<int:id>", view_func=report_data_view, methods=["GET"])
 
 report_generator_view = RecommendationGenerator.as_view("generate_report")
 api.add_url_rule("/generate", view_func=report_generator_view, methods=["POST"])

--- a/project/app/modules/foliage_report/templates/ver_reporte.j2
+++ b/project/app/modules/foliage_report/templates/ver_reporte.j2
@@ -288,65 +288,82 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Solo intentar crear gráficos si los datos están disponibles
-            const foliarChartData = {{ foliarChartData|tojson|safe or 'null' }};
-            const soilChartData = {{ soilChartData|tojson|safe or 'null' }};
-            const historicalData = {{ historicalData|tojson|safe or 'null' }};
+            const chartColors = {
+                actual: 'rgba(59, 130, 246, 0.7)',
+                min: 'rgba(239, 68, 68, 0.5)',
+                max: 'rgba(245, 158, 11, 0.5)'
+            };
+            fetch('{{ url_for("foliage_report_api.report_data", id=report_id) }}')
+                .then(r => r.json())
+                .then(data => {
+                    const short = { nitrogeno:'N', fosforo:'P', potasio:'K', calcio:'Ca', magnesio:'Mg', azufre:'S', hierro:'Fe', manganeso:'Mn', zinc:'Zn', cobre:'Cu', boro:'B', ph:'pH', materiaOrganica:'M.O.', cic:'CIC' };
+                    const analysis = data.analysisData || {};
+                    const optimal = data.optimalLevels || {};
+                    const foliarChartData = [];
+                    if (analysis.foliar && optimal.foliar) {
+                        for (const [k,v] of Object.entries(analysis.foliar)) {
+                            const lvl = optimal.foliar[k];
+                            if (lvl && typeof v === 'number') {
+                                foliarChartData.push({name: short[k]||k, actual:v, min:lvl.min, max:lvl.max});
+                            }
+                        }
+                    }
+                    const soilChartData = [];
+                    if (analysis.soil && optimal.soil) {
+                        for (const [k,v] of Object.entries(analysis.soil)) {
+                            const lvl = optimal.soil[k];
+                            if (lvl && typeof v === 'number') {
+                                soilChartData.push({name: short[k]||k, actual:v, min:lvl.min, max:lvl.max});
+                            }
+                        }
+                    }
+                    const historicalData = data.historicalData || [];
 
-            // Configuración de gráficos (solo si hay datos)
-            if (foliarChartData && document.getElementById('foliarChart')) {
-                 const foliarChartCtx = document.getElementById('foliarChart').getContext('2d');
-                 new Chart(foliarChartCtx, {
-                     type: 'bar', // o 'radar'
-                     data: {
-                         labels: foliarChartData.map(d => d.name),
-                         datasets: [
-                             {
-                                 label: 'Nivel Actual',
-                                 data: foliarChartData.map(d => d.actual),
-                                 backgroundColor: 'rgba(54, 162, 235, 0.6)', // Azul
-                                 borderColor: 'rgba(54, 162, 235, 1)',
-                                 borderWidth: 1
-                             },
-                              {
-                                 label: 'Rango Óptimo',
-                                 data: foliarChartData.map(d => [d.min, d.max]), // Para mostrar rango
-                                 // Opciones para mostrar rango (puede requerir plugins o configuración específica)
-                                  type: 'line', // Podría ser una línea o área para el rango
-                                  fill: '+1', // Rellenar hasta el siguiente dataset (max)
-                                  backgroundColor: 'rgba(75, 192, 192, 0.2)', // Verde claro
-                                  borderColor: 'rgba(75, 192, 192, 0.5)',
-                                  pointRadius: 0,
-                                  data: foliarChartData.map(d => d.min), // Línea mínima
-                              },
-                               {
-                                  // Dataset para la línea máxima del rango
-                                  data: foliarChartData.map(d => d.max),
-                                  type: 'line',
-                                  fill: false,
-                                  borderColor: 'rgba(75, 192, 192, 0.5)',
-                                  pointRadius: 0,
-                                  showLine: false // Opcional: ocultar la línea si solo quieres el área
-                              }
-                         ]
-                     },
-                     options: { // Opciones básicas
-                         responsive: true,
-                         maintainAspectRatio: false,
-                          plugins: { legend: { display: true } }
-                     }
-                 });
-            }
+            const foliarChartCtx = document.getElementById('foliarChart').getContext('2d');
+            new Chart(foliarChartCtx, {
+                type: 'bar',
+                data: {
+                    labels: foliarChartData.map(d => d.name),
+                    datasets: [
+                        { label: 'Nivel Actual', data: foliarChartData.map(d => d.actual), backgroundColor: chartColors.actual },
+                        { label: 'Nivel Mínimo', data: foliarChartData.map(d => d.min), backgroundColor: chartColors.min },
+                        { label: 'Nivel Máximo', data: foliarChartData.map(d => d.max), backgroundColor: chartColors.max }
+                    ]
+                },
+                options: { responsive: true, maintainAspectRatio: false, plugins: { legend: { display: true } } }
+            });
 
-            if (soilChartData && document.getElementById('soilChart')) {
-                const soilChartCtx = document.getElementById('soilChart').getContext('2d');
-                 // ... (Configuración similar para soilChart) ...
-            }
+            const soilChartCtx = document.getElementById('soilChart').getContext('2d');
+            new Chart(soilChartCtx, {
+                type: 'bar',
+                data: {
+                    labels: soilChartData.map(d => d.name),
+                    datasets: [
+                        { label: 'Nivel Actual', data: soilChartData.map(d => d.actual), backgroundColor: 'hsl(var(--chart-1))' },
+                        { label: 'Nivel Mínimo', data: soilChartData.map(d => d.min), backgroundColor: 'hsl(var(--chart-3))' },
+                        { label: 'Nivel Máximo', data: soilChartData.map(d => d.max), backgroundColor: 'hsl(var(--chart-4))' }
+                    ]
+                },
+                options: { responsive: true, plugins: { legend: { position: 'top' }, title: { display: true, text: 'Niveles de Nutrientes de Suelo' } } }
+            });
 
-            if (historicalData && document.getElementById('historyChart')) {
-                const historyChartCtx = document.getElementById('historyChart').getContext('2d');
-                // ... (Configuración similar para historyChart) ...
-            }
+            const historyChartCtx = document.getElementById('historyChart').getContext('2d');
+            new Chart(historyChartCtx, {
+                type: 'line',
+                data: {
+                    labels: historicalData.map(d => d.fecha),
+                    datasets: [
+                        { label: 'Nitrógeno', data: historicalData.map(d => d.nitrogeno), fill: false, borderColor: 'hsl(var(--color-nitrogeno))', tension: 0.1 },
+                        { label: 'Fósforo', data: historicalData.map(d => d.fosforo), fill: false, borderColor: 'hsl(var(--color-fosforo))', tension: 0.1 },
+                        { label: 'Potasio', data: historicalData.map(d => d.potasio), fill: false, borderColor: 'hsl(var(--color-potasio))', tension: 0.1 }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    plugins: { legend: { position: 'top' }, title: { display: true, text: 'Historial de Análisis' } },
+                    scales: { x: { display: true, title: { display: true, text: 'Fecha' } }, y: { display: true, title: { display: true, text: 'Nivel (%)' } } }
+                }
+            });
 
             // Manejo de tabs
             const tabs = document.querySelectorAll('.tabs-trigger');

--- a/project/app/modules/foliage_report/templates/ver_reporte2.j2
+++ b/project/app/modules/foliage_report/templates/ver_reporte2.j2
@@ -728,148 +728,91 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Configuración de gráficos de análisis foliar
-            const foliarChartCtx = document.getElementById('foliarChart').getContext('2d');
             const chartColors = {
-                actual: 'rgba(59, 130, 246, 0.7)',    // Blue-500
-                min: 'rgba(239, 68, 68, 0.5)',      // Red-500
-                max: 'rgba(245, 158, 11, 0.5)',     // Amber-500
+                actual: 'rgba(59, 130, 246, 0.7)',
+                min: 'rgba(239, 68, 68, 0.5)',
+                max: 'rgba(245, 158, 11, 0.5)'
             };
-            new Chart(foliarChartCtx, {
-                type: 'bar',
-                data: {
-                    labels: {{ foliarChartData|map(attribute='name')|list|tojson }},
-                    datasets: [
-                        {
-                            label: 'Nivel Actual',
-                            data: {{ foliarChartData|map(attribute='actual')|list|tojson }},
-                            backgroundColor: chartColors.actual,
-                        },
-                        {
-                            label: 'Nivel Mínimo',
-                            data: {{ foliarChartData|map(attribute='min')|list|tojson }},
-                            backgroundColor: chartColors.min,
-                        },
-                        {
-                            label: 'Nivel Máximo',
-                            data: {{ foliarChartData|map(attribute='max')|list|tojson }},
-                            backgroundColor: chartColors.max,
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                        },
-                        title: {
-                            display: true,
-                            text: 'Niveles de Nutrientes Folares'
-                        }
-                    }
-                }
-            });
-
-            // Configuración de gráficos de análisis de suelo
-            const soilChartCtx = document.getElementById('soilChart').getContext('2d');
-            new Chart(soilChartCtx, {
-                type: 'bar',
-                data: {
-                    labels: {{ soilChartData|map(attribute='name')|list|tojson }},
-                    datasets: [
-                        {
-                            label: 'Nivel Actual',
-                            data: {{ soilChartData|map(attribute='actual')|list|tojson }},
-                            backgroundColor: 'hsl(var(--chart-1))',
-                        },
-                        {
-                            label: 'Nivel Mínimo',
-                            data: {{ soilChartData|map(attribute='min')|list|tojson }},
-                            backgroundColor: 'hsl(var(--chart-3))',
-                        },
-                        {
-                            label: 'Nivel Máximo',
-                            data: {{ soilChartData|map(attribute='max')|list|tojson }},
-                            backgroundColor: 'hsl(var(--chart-4))',
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                        },
-                        title: {
-                            display: true,
-                            text: 'Niveles de Nutrientes de Suelo'
-                        }
-                    }
-                }
-            });
-
-            // Configuración de gráficos histórico
-            const historyChartCtx = document.getElementById('historyChart').getContext('2d');
-            new Chart(historyChartCtx, {
-                type: 'line',
-                data: {
-                    labels: {{ historicalData|map(attribute='fecha')|list|tojson }},
-                    datasets: [
-                        {
-                            label: 'Nitrógeno',
-                            data: {{ historicalData|map(attribute='nitrogeno')|list|tojson }},
-                            fill: false,
-                            borderColor: 'hsl(var(--color-nitrogeno))',
-                            tension: 0.1
-                        },
-                        {
-                            label: 'Fósforo',
-                            data: {{ historicalData|map(attribute='fosforo')|list|tojson }},
-                            fill: false,
-                            borderColor: 'hsl(var(--color-fosforo))',
-                            tension: 0.1
-                        },
-                        {
-                            label: 'Potasio',
-                            data: {{ historicalData|map(attribute='potasio')|list|tojson }},
-                            fill: false,
-                            borderColor: 'hsl(var(--color-potasio))',
-                            tension: 0.1
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                        },
-                        title: {
-                            display: true,
-                            text: 'Historial de Análisis'
-                        }
-                    },
-                    scales: {
-                        x: {
-                            display: true,
-                            title: {
-                                display: true,
-                                text: 'Fecha'
-                            }
-                        },
-                        y: {
-                            display: true,
-                            title: {
-                                display: true,
-                                text: 'Nivel (%)'
+            fetch('{{ url_for("foliage_report_api.report_data", id=report_id) }}')
+                .then(r => r.json())
+                .then(data => {
+                    const short = {
+                        nitrogeno: 'N', fosforo: 'P', potasio: 'K', calcio: 'Ca', magnesio: 'Mg', azufre: 'S',
+                        hierro: 'Fe', manganeso: 'Mn', zinc: 'Zn', cobre: 'Cu', boro: 'B',
+                        ph: 'pH', materiaOrganica: 'M.O.', cic: 'CIC'
+                    };
+                    const analysis = data.analysisData || {};
+                    const optimal = data.optimalLevels || {};
+                    const foliarChartData = [];
+                    if (analysis.foliar && optimal.foliar) {
+                        for (const [k, v] of Object.entries(analysis.foliar)) {
+                            const lvl = optimal.foliar[k];
+                            if (lvl && typeof v === 'number') {
+                                foliarChartData.push({name: short[k] || k, actual: v, min: lvl.min, max: lvl.max});
                             }
                         }
                     }
-                }
-            });
+                    const soilChartData = [];
+                    if (analysis.soil && optimal.soil) {
+                        for (const [k, v] of Object.entries(analysis.soil)) {
+                            const lvl = optimal.soil[k];
+                            if (lvl && typeof v === 'number') {
+                                soilChartData.push({name: short[k] || k, actual: v, min: lvl.min, max: lvl.max});
+                            }
+                        }
+                    }
+                    const historicalData = data.historicalData || [];
 
-            // Manejo de tabs
+                    const foliarChartCtx = document.getElementById('foliarChart').getContext('2d');
+                    new Chart(foliarChartCtx, {
+                        type: 'bar',
+                        data: {
+                            labels: foliarChartData.map(d => d.name),
+                            datasets: [
+                                { label: 'Nivel Actual', data: foliarChartData.map(d => d.actual), backgroundColor: chartColors.actual },
+                                { label: 'Nivel Mínimo', data: foliarChartData.map(d => d.min), backgroundColor: chartColors.min },
+                                { label: 'Nivel Máximo', data: foliarChartData.map(d => d.max), backgroundColor: chartColors.max }
+                            ]
+                        },
+                        options: { responsive: true, plugins: { legend: { position: 'top' }, title: { display: true, text: 'Niveles de Nutrientes Folares' } } }
+                    });
+
+                    const soilChartCtx = document.getElementById('soilChart').getContext('2d');
+                    new Chart(soilChartCtx, {
+                        type: 'bar',
+                        data: {
+                            labels: soilChartData.map(d => d.name),
+                            datasets: [
+                                { label: 'Nivel Actual', data: soilChartData.map(d => d.actual), backgroundColor: 'hsl(var(--chart-1))' },
+                                { label: 'Nivel Mínimo', data: soilChartData.map(d => d.min), backgroundColor: 'hsl(var(--chart-3))' },
+                                { label: 'Nivel Máximo', data: soilChartData.map(d => d.max), backgroundColor: 'hsl(var(--chart-4))' }
+                            ]
+                        },
+                        options: { responsive: true, plugins: { legend: { position: 'top' }, title: { display: true, text: 'Niveles de Nutrientes de Suelo' } } }
+                    });
+
+                    const historyChartCtx = document.getElementById('historyChart').getContext('2d');
+                    new Chart(historyChartCtx, {
+                        type: 'line',
+                        data: {
+                            labels: historicalData.map(d => d.fecha),
+                            datasets: [
+                                { label: 'Nitrógeno', data: historicalData.map(d => d.nitrogeno), fill: false, borderColor: 'hsl(var(--color-nitrogeno))', tension: 0.1 },
+                                { label: 'Fósforo', data: historicalData.map(d => d.fosforo), fill: false, borderColor: 'hsl(var(--color-fosforo))', tension: 0.1 },
+                                { label: 'Potasio', data: historicalData.map(d => d.potasio), fill: false, borderColor: 'hsl(var(--color-potasio))', tension: 0.1 }
+                            ]
+                        },
+                        options: {
+                            responsive: true,
+                            plugins: { legend: { position: 'top' }, title: { display: true, text: 'Historial de Análisis' } },
+                            scales: {
+                                x: { display: true, title: { display: true, text: 'Fecha' } },
+                                y: { display: true, title: { display: true, text: 'Nivel (%)' } }
+                            }
+                        }
+                    });
+                });
+
             const tabs = document.querySelectorAll('.tabs-trigger');
             tabs.forEach(tab => {
                 tab.addEventListener('click', function() {

--- a/project/app/modules/foliage_report/web_routes.py
+++ b/project/app/modules/foliage_report/web_routes.py
@@ -643,8 +643,20 @@ def vista_report():
     limitingNutrient = findLimitingNutrient()
     recommendations = generateRecommendations()
 
-    return render_template('ver_reporte2.j2', **context, 
-            request=request,  analysisData=analysisData, optimalLevels=optimalLevels, foliarChartData=foliarChartData, soilChartData=soilChartData, historicalData=historicalData, nutrientNames=nutrientNames, limitingNutrient=limitingNutrient, recommendations=recommendations)
+    return render_template(
+        'ver_reporte2.j2',
+        **context,
+        request=request,
+        report_id=report_id,
+        analysisData=analysisData,
+        optimalLevels=optimalLevels,
+        foliarChartData=foliarChartData,
+        soilChartData=soilChartData,
+        historicalData=historicalData,
+        nutrientNames=nutrientNames,
+        limitingNutrient=limitingNutrient,
+        recommendations=recommendations
+    )
 
 
 


### PR DESCRIPTION
## Summary
- expose `/data/<id>` route in foliage_report API
- pass report ID when rendering `ver_reporte2.j2`
- fetch JSON data for charts in `ver_reporte2.j2` and `ver_reporte.j2`

## Testing
- `pytest -q`
- `ruff check .` *(fails: E/F issues)*

------
https://chatgpt.com/codex/tasks/task_e_6846949d052c832e8cf120d69c95cd7c