### PR TITLE
Fix foliage_report blueprint formatting

### DIFF
--- a/project/app/modules/foliage_report/__init__.py
+++ b/project/app/modules/foliage_report/__init__.py
@@ -1,10 +1,9 @@
 from flask import Blueprint
 
-foliage_report = Blueprint(
-    "foliage_report", __name__, url_prefix="/dashboard/foliage_report", template_folder="templates"
-)
-foliage_report_api = Blueprint(
-    "foliage_report_api", __name__, url_prefix="/api/foliage/report"
-    )
+foliage_report = Blueprint("foliage_report", __name__,
+                            url_prefix="/dashboard/foliage_report",
+                            template_folder="templates")
+foliage_report_api = Blueprint("foliage_report_api", __name__,
+                               url_prefix="/api/foliage/report")
 
 from . import web_routes, api_routes


### PR DESCRIPTION
## Summary
- fix formatting of blueprint definitions in `foliage_report/__init__.py`
- ensure newline at EOF

## Testing
- `make test` *(fails: cannot open venv/bin/activate)*

------
https://chatgpt.com/codex/tasks/task_e_6849fbaa871c832eaacca19c4ee9c8d7