### PR TITLE
Fix optional nutrient contributions

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -1423,6 +1423,8 @@ class ProductContributionView(MethodView):
             k: v for k, v in data.items() if k.startswith("nutrient_")
         }
         for key, value in nutrient_contributions.items():
+            if value in (None, "", "null"):
+                continue
             nutrient_id = int(key.split("_")[1])
             nutrient = Nutrient.query.get(nutrient_id)
             if not nutrient:
@@ -1470,6 +1472,8 @@ class ProductContributionView(MethodView):
             ).delete()
             # Add new nutrient contributions
             for key, value in nutrient_contributions.items():
+                if value in (None, "", "null"):
+                    continue
                 nutrient_id = int(key.split("_")[1])
                 nutrient = Nutrient.query.get(nutrient_id)
                 if not nutrient:


### PR DESCRIPTION
## Summary
- handle empty nutrient fields when creating and updating product contributions

## Testing
- `make lint` *(fails: project/venv/bin/flake8: No such file or directory)*
- `make test` *(fails: project/venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68522cafe2b8832e85ac485176e363f2