### PR TITLE
Fix optional nutrient contributions

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -1,6 +1,6 @@
 # Python standard library imports
 import json
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 # Third party imports
 from flask_jwt_extended import jwt_required, get_jwt
@@ -1423,6 +1423,8 @@ class ProductContributionView(MethodView):
             k: v for k, v in data.items() if k.startswith("nutrient_")
         }
         for key, value in nutrient_contributions.items():
+            if value in (None, "", "null"):
+                continue
             nutrient_id = int(key.split("_")[1])
             nutrient = Nutrient.query.get(nutrient_id)
             if not nutrient:
@@ -1470,6 +1472,8 @@ class ProductContributionView(MethodView):
             ).delete()
             # Add new nutrient contributions
             for key, value in nutrient_contributions.items():
+                if value in (None, "", "null"):
+                    continue
                 nutrient_id = int(key.split("_")[1])
                 nutrient = Nutrient.query.get(nutrient_id)
                 if not nutrient:
@@ -1636,10 +1640,24 @@ class ProductPriceView(MethodView):
         if existing_price:
             raise Conflict("Ya existe un precio para este producto")
         price = data["price"]
-        start_date = data["start_date"]
-        end_date = data["end_date"]
+        start_date_str = data.get("start_date")
+        end_date_str = data.get("end_date")
+
+        if start_date_str:
+            start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+        else:
+            start_date = date.today()
+
+        if end_date_str:
+            end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+        else:
+            end_date = start_date + timedelta(days=365)
+
         product_price = ProductPrice(
-            product_id=product_id, price=price, start_date=start_date, end_date=end_date
+            product_id=product_id,
+            price=price,
+            start_date=start_date,
+            end_date=end_date,
         )
         db.session.add(product_price)
         db.session.commit()
@@ -1653,9 +1671,13 @@ class ProductPriceView(MethodView):
         if "price" in data:
             product_price.price = data["price"]
         if "start_date" in data:
-            product_price.start_date = data["start_date"]
+            product_price.start_date = datetime.strptime(
+                data["start_date"], "%Y-%m-%d"
+            ).date()
         if "end_date" in data:
-            product_price.end_date = data["end_date"]
+            product_price.end_date = datetime.strptime(
+                data["end_date"], "%Y-%m-%d"
+            ).date()
         db.session.commit()
         response_data = self._serialize_product_price(product_price)
         json_data = json.dumps(response_data, ensure_ascii=False, indent=4)

--- a/project/app/modules/foliage/models.py
+++ b/project/app/modules/foliage/models.py
@@ -1,6 +1,6 @@
 from app.extensions import db, cache
 from app.core.models import User
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from marshmallow import Schema, fields, validates, ValidationError
 from enum import Enum
 
@@ -151,8 +151,8 @@ class LotCrop(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     lot_id = db.Column(db.Integer, db.ForeignKey("lots.id"), nullable=False)
     crop_id = db.Column(db.Integer, db.ForeignKey("crops.id"), nullable=False)
-    start_date = db.Column(db.Date, nullable=False)
-    end_date = db.Column(db.Date)
+    start_date = db.Column(db.Date, nullable=False, default=date.today)
+    end_date = db.Column(db.Date, default=lambda: date.today() + timedelta(days=365))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -494,8 +494,8 @@ class ProductPrice(db.Model):
     product_id = db.Column(db.Integer, db.ForeignKey("products.id"), nullable=False)
     price = db.Column(db.Float, nullable=False)
     supplier = db.Column(db.String(100))
-    start_date = db.Column(db.Date, nullable=False)
-    end_date = db.Column(db.Date)
+    start_date = db.Column(db.Date, nullable=False, default=date.today)
+    end_date = db.Column(db.Date, default=lambda: date.today() + timedelta(days=365))
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/project/app/modules/foliage/templates/product_prices.j2
+++ b/project/app/modules/foliage/templates/product_prices.j2
@@ -17,3 +17,28 @@
 {# entregado desde el endpoint #}
 {# api de consumo #}
 {% set api_url = url_for('foliage_api.product_price_view') %}
+
+{% block extra_js %}
+{{ super() }}
+<script>
+    const originalShowModal = showModal;
+    showModal = function(action, id = null) {
+        originalShowModal(action, id);
+        if (action === 'create') {
+            const startInput = document.getElementById('start_date');
+            const endInput = document.getElementById('end_date');
+            if (startInput && endInput) {
+                const today = new Date();
+                const todayStr = today.toISOString().split('T')[0];
+                startInput.value = todayStr;
+                startInput.setAttribute('value', todayStr);
+                const nextYear = new Date(today);
+                nextYear.setFullYear(nextYear.getFullYear() + 1);
+                const nextYearStr = nextYear.toISOString().split('T')[0];
+                endInput.value = nextYearStr;
+                endInput.setAttribute('value', nextYearStr);
+            }
+        }
+    };
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- handle empty nutrient fields when creating and updating product contributions
- default product price dates to today and a year later

## Testing
- `make lint` *(fails: project/venv/bin/flake8: No such file or directory)*
- `make test` *(fails: project/venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68522cafe2b8832e85ac485176e363f2