### PR TITLE
Fix optional nutrients in leaf analyses

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -2439,6 +2439,8 @@ class LeafAnalysisView(MethodView):
         # Manejar valores de nutrientes
         nutrient_values = {k: v for k, v in data.items() if k.startswith("nutrient_")}
         for key, value in nutrient_values.items():
+            if value is None or str(value).strip() == "":
+                continue
             nutrient_id = int(key.split("_")[1])
             nutrient = Nutrient.query.get(nutrient_id)
             if not nutrient:
@@ -2485,6 +2487,8 @@ class LeafAnalysisView(MethodView):
             ).delete()
             # Agregar nuevos valores de nutrientes
             for key, value in nutrient_values.items():
+                if value is None or str(value).strip() == "":
+                    continue
                 nutrient_id = int(key.split("_")[1])
                 nutrient = Nutrient.query.get(nutrient_id)
                 if not nutrient:

--- a/project/app/modules/foliage/templates/leaf_analyses.j2
+++ b/project/app/modules/foliage/templates/leaf_analyses.j2
@@ -46,15 +46,13 @@ function fillFormWithData(id) {
         document.getElementById('{{ entity_name_lower }}Id').value = item.id;
         document.getElementById('common_analysis_id').value = item.common_analysis_id || '';
         
-        // Cambia nutrient_targets por nutrient_values
-        if (item.nutrient_values) {
-            item.nutrient_values.forEach(target => {
-                const field = document.getElementById(`nutrient_${target.nutrient_id}`);
-                if (field) {
-                    field.value = target.value || ''; // Cambia target_value por value
-                }
-            });
-        }
+        const nutrientIds = {{ nutrient_ids | map(attribute='id') | list | tojson | safe }};
+        nutrientIds.forEach(id => {
+            const field = document.getElementById(`nutrient_${id}`);
+            if (field) {
+                field.value = item[`nutrient_${id}`] || '';
+            }
+        });
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- allow blank nutrient values when creating/updating leaf analyses
- populate nutrient fields correctly when viewing an analysis

## Testing
- `make test` *(fails: project/venv/bin/pytest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523f68ccc8832e86f225de63fd360b