### PR TITLE
Add lot area column and rename month label

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -1992,6 +1992,7 @@ class CommonAnalysisView(MethodView):
             "date": common_analysis.date.isoformat() if common_analysis.date else None,
             "lot_id": common_analysis.lot_id,
             "lot_name": common_analysis.lot.name,
+            "lot_area": common_analysis.lot.area,
             "farm_name": common_analysis.lot.farm.name,
             "protein": common_analysis.protein,
             "energy": common_analysis.energy,

--- a/project/app/modules/foliage/templates/common_analyses.j2
+++ b/project/app/modules/foliage/templates/common_analyses.j2
@@ -4,8 +4,36 @@
 {% set entity_name_lower = "analisis_comun" %}
 {% set show_select_box = True %}
 {# Mostrar la grid de ítems #}
-{% set table_headers = ["ID", "Fecha de análisis", "Finca", "Lote", "Energía", "Proteínas", "Aforo", "Descanso", "Días de descanso", "Mes", "Fecha de creación", "Fecha de actualización"] %}
-{% set item_fields = ["id", "date", "farm_name", "lot_name", "energy", "protein", "yield_estimate", "rest", "rest_days", "month", "created_at", "updated_at"] %}
+{% set table_headers = [
+    "ID",
+    "Fecha de análisis",
+    "Finca",
+    "Lote",
+    "Área del lote",
+    "Energía",
+    "Proteínas",
+    "Aforo",
+    "Descanso",
+    "Días de descanso",
+    "Ciclo de Pastoreo",
+    "Fecha de creación",
+    "Fecha de actualización"
+] %}
+{% set item_fields = [
+    "id",
+    "date",
+    "farm_name",
+    "lot_name",
+    "lot_area",
+    "energy",
+    "protein",
+    "yield_estimate",
+    "rest",
+    "rest_days",
+    "month",
+    "created_at",
+    "updated_at"
+] %}
 {# formulario de editar y add #}
 {% set form_fields = {
     'date': {'type': 'date', 'label': 'Fecha de análisis', 'required': True},
@@ -15,7 +43,7 @@
     'rest': {'type': 'number', 'label': 'Descanso', 'required': True},
     'rest_days': {'type': 'number', 'label': 'Días de descanso', 'required': True},
     'yield_estimate': {'type': 'number', 'label': 'Aforo', 'required': True},
-    'month': {'type': 'number', 'label': 'Mes', "min": 1, "max": 12, 'required': True},
+    'month': {'type': 'number', 'label': 'Ciclo de Pastoreo', "min": 1, "max": 12, 'required': True},
 } %}
 {# entregado desde el endpoint #}
 {# api de consumo #}


### PR DESCRIPTION
## Summary
- add `lot_area` to common analysis serialization
- display lot area column and rename `Mes` header/label to "Ciclo de Pastoreo"

## Testing
- `make test` *(fails: project/venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68536747455c832eadf27f874671ec21