### PR TITLE
Add supplier field in product price form

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -1640,6 +1640,7 @@ class ProductPriceView(MethodView):
         if existing_price:
             raise Conflict("Ya existe un precio para este producto")
         price = data["price"]
+        supplier = data.get("supplier")
         start_date_str = data.get("start_date")
         end_date_str = data.get("end_date")
 
@@ -1656,6 +1657,7 @@ class ProductPriceView(MethodView):
         product_price = ProductPrice(
             product_id=product_id,
             price=price,
+            supplier=supplier,
             start_date=start_date,
             end_date=end_date,
         )
@@ -1670,6 +1672,8 @@ class ProductPriceView(MethodView):
         product_price = ProductPrice.query.get_or_404(product_price_id)
         if "price" in data:
             product_price.price = data["price"]
+        if "supplier" in data:
+            product_price.supplier = data["supplier"]
         if "start_date" in data:
             product_price.start_date = datetime.strptime(
                 data["start_date"], "%Y-%m-%d"
@@ -1701,6 +1705,7 @@ class ProductPriceView(MethodView):
             "product_id": product_price.product_id,
             "product_name": product_price.product.name,
             "price": product_price.price,
+            "supplier": product_price.supplier,
             "start_date": (
                 product_price.start_date.isoformat()
                 if product_price.start_date

--- a/project/app/modules/foliage/templates/product_prices.j2
+++ b/project/app/modules/foliage/templates/product_prices.j2
@@ -4,13 +4,14 @@
 {% set entity_name_lower = "precio_de_producto" %}
 {% set show_select_box = False %}
 {# Mostrar la grid de ítems #}
-{% set table_headers = ["ID", "Producto", "Precio", "Fecha de inicio", "Fecha de fin", "Fecha de creación", "Fecha de actualización"] %}
-{% set item_fields = ["id", "product_name", "price", "start_date", "end_date", "created_at", "updated_at"] %}
+{% set table_headers = ["ID", "Producto", "Precio", "Proveedor", "Fecha de inicio", "Fecha de fin", "Fecha de creación", "Fecha de actualización"] %}
+{% set item_fields = ["id", "product_name", "price", "supplier", "start_date", "end_date", "created_at", "updated_at"] %}
 
 {# formulario de editar y add #}
 {% set form_fields = {
     'product_id': {'type': 'select', 'label': 'ID del producto', 'options': product_options, 'required': True},
     'price': {'type': 'number', 'label': 'Precio', 'required': True},
+    'supplier': {'type': 'text', 'label': 'Proveedor', 'required': False},
     'start_date': {'type': 'date', 'label': 'Fecha de inicio', 'required': True},
     'end_date': {'type': 'date', 'label': 'Fecha Final', 'required': True},
 } %}


### PR DESCRIPTION
## Summary
- include supplier in product price table and form
- handle supplier on create, update and serialize

## Testing
- `make test` *(fails: project/venv/bin/pytest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cb2b6a9ec832ea7db1296cf53a0c0