### PR TITLE
Fix objective dropdown

### DIFF
--- a/project/app/modules/foliage_report/api_routes.py
+++ b/project/app/modules/foliage_report/api_routes.py
@@ -117,6 +117,23 @@ def get_objectives_for_crop(crop_id):
     return jsonify(objectives_data)
 
 
+@api.route("/get-objectives")
+@login_required
+def get_all_objectives():
+    """Return a list of all objectives with their crop names."""
+    objectives = Objective.query.all()
+    data = [
+        {
+            "cultivo": obj.crop.name,
+            "crop_id": obj.crop_id,
+            "id": obj.id,
+            "name": f"ID: {obj.id} - Target: {obj.target_value}",
+        }
+        for obj in objectives
+    ]
+    return jsonify(data)
+
+
 @api.route("/analyses")
 @login_required
 def get_analyses():

--- a/project/app/modules/foliage_report/templates/solicitar_informe2.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe2.j2
@@ -273,34 +273,34 @@
                     errorMessage.classList.remove('hidden');
                 });
 
-            // Fetch objectives for the crop
-            if (cropId) {
-                objectiveSelect.disabled = false; // Enable before fetch
-                fetch(`{{ url_for('foliage_report_api.get_objectives_for_crop', crop_id=0) }}`.replace('0', cropId))
-                    .then(response => {
-                        if (!response.ok) throw new Error('Error al cargar objetivos');
-                        return response.json();
-                    })
-                    .then(objectives => {
-                        resetSelect(objectiveSelect, 'Seleccione un objetivo...');
-                        objectives.forEach(obj => {
-                            const option = new Option(`${obj.cultivo} - ${obj.name}`, obj.id);
-                            objectiveSelect.add(option);
-                        });
-                        if (document.getElementById('debug-objectives-data')) {
-                            document.getElementById('debug-objectives-data').textContent = JSON.stringify(objectives, null, 2);
+            // Fetch all objectives and pre-select those matching the crop
+            objectiveSelect.disabled = false; // Enable before fetch
+            fetch(`{{ url_for('foliage_report_api.get_all_objectives') }}`)
+                .then(response => {
+                    if (!response.ok) throw new Error('Error al cargar objetivos');
+                    return response.json();
+                })
+                .then(objectives => {
+                    resetSelect(objectiveSelect, 'Seleccione un objetivo...');
+                    objectives.forEach(obj => {
+                        const option = new Option(`${obj.cultivo} - ${obj.name}`, obj.id);
+                        option.dataset.cropId = obj.crop_id;
+                        if (cropId && String(obj.crop_id) === String(cropId)) {
+                            option.selected = true;
                         }
-                        objectiveSelect.disabled = false;
-                    })
-                    .catch(error => {
-                        console.error(error);
-                        resetSelect(objectiveSelect, 'Error al cargar objetivos');
-                        errorMessage.textContent = 'Error al cargar objetivos.';
-                        errorMessage.classList.remove('hidden');
+                        objectiveSelect.add(option);
                     });
-            } else {
-                resetSelect(objectiveSelect, 'Cultivo no definido para este lote.');
-            }
+                    if (document.getElementById('debug-objectives-data')) {
+                        document.getElementById('debug-objectives-data').textContent = JSON.stringify(objectives, null, 2);
+                    }
+                    objectiveSelect.disabled = false;
+                })
+                .catch(error => {
+                    console.error(error);
+                    resetSelect(objectiveSelect, 'Error al cargar objetivos');
+                    errorMessage.textContent = 'Error al cargar objetivos.';
+                    errorMessage.classList.remove('hidden');
+                });
         });
 
 


### PR DESCRIPTION
## Summary
- add API route to list all objectives
- load all objectives on lot change and preselect current crop

## Testing
- `make format` *(fails: project/venv/bin/black: No such file or directory)*
- `make lint` *(fails: project/venv/bin/flake8: No such file or directory)*
- `make test` *(fails: project/venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685cf56cc484832e9950e05d40b2cd25