### PR TITLE
Agrega visualización de nutrientes objetivo del cultivo en la página …

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -644,11 +644,31 @@ class CropView(MethodView):
 
     def _serialize_crop(self, crop):
         """Serializa un objeto Crop a un diccionario."""
+        # Obtener los objetivos asociados al cultivo
+        objectives_data = []
+        for objective in crop.objectives: # Asumiendo que crop.objectives es la relación
+            nutrient_targets = (
+                db.session.query(objective_nutrients)
+                .filter_by(objective_id=objective.id)
+                .all()
+            )
+            objectives_data.extend([
+                {
+                    "nutrient_id": target.nutrient_id,
+                    "target_value": target.target_value,
+                    "nutrient_name": Nutrient.query.get(target.nutrient_id).name,
+                    "nutrient_symbol": Nutrient.query.get(target.nutrient_id).symbol,
+                    "nutrient_unit": Nutrient.query.get(target.nutrient_id).unit,
+                }
+                for target in nutrient_targets
+            ])
+
         return {
             "id": crop.id,
             "name": crop.name,
             "created_at": crop.created_at.isoformat(),
             "updated_at": crop.updated_at.isoformat(),
+            "objective_nutrients": objectives_data, # Añadir los nutrientes objetivo
         }
 
 

--- a/project/app/modules/foliage_report/templates/solicitar_informe2.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe2.j2
@@ -174,7 +174,18 @@
                     return response.json();
                 })
                 .then(crop => {
-                    cropInfoContent.textContent = `ID: ${crop.id} - ${crop.name}`;
+                    let content = `<p><strong>ID:</strong> ${crop.id}</p>`;
+                    content += `<p><strong>Nombre:</strong> ${crop.name}</p>`;
+                    if (crop.objective_nutrients && crop.objective_nutrients.length > 0) {
+                        content += '<p><strong>Nutrientes Objetivo:</strong></p><ul>';
+                        crop.objective_nutrients.forEach(on => {
+                            content += `<li>${on.nutrient_name} (${on.nutrient_symbol}): ${on.target_value} ${on.nutrient_unit}</li>`;
+                        });
+                        content += '</ul>';
+                    } else {
+                        content += '<p>No hay nutrientes objetivo definidos para este cultivo.</p>';
+                    }
+                    cropInfoContent.innerHTML = content;
                     cropInfoDiv.classList.remove('hidden');
                 })
                 .catch(error => {


### PR DESCRIPTION
…de generar informe

Modifica el template `solicitar_informe2.j2` para mostrar los `objective_nutrients` del cultivo seleccionado en la sección "Información del Cultivo".

Actualiza el controlador `CropView` para incluir los `objective_nutrients` en la serialización de la respuesta de la API de cultivos.