### PR TITLE
Actualiza dinámicamente info de cultivo al cambiar selección de objetivo

### DIFF
--- a/project/app/modules/foliage_report/templates/solicitar_informe2.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe2.j2
@@ -396,6 +396,14 @@
                 });
         });
 
+        // Actualizar información del cultivo cuando cambia el objetivo seleccionado
+        objectiveSelect.addEventListener('change', function() {
+            const selectedOption = this.options[this.selectedIndex];
+            let cropId = selectedOption.dataset.cropId;
+             if (!cropId || cropId === 'null') cropId = '';
+            updateCropInfo(cropId);
+        });
+
 
         // Enviar formulario para generar reporte
         form.addEventListener('submit', function(event) {


### PR DESCRIPTION
Modifica el JavaScript en `solicitar_informe2.j2` para que la sección "Información del Cultivo" se actualice cuando el usuario cambia la selección en el desplegable "Objetivo".

Esto permite al usuario ver los detalles y nutrientes objetivo del cultivo asociado al objetivo seleccionado explícitamente, además de la actualización que ya ocurría al seleccionar un lote.