### PR TITLE
Implement Liebig balance computation

### DIFF
--- a/project/app/modules/foliage/api_routes.py
+++ b/project/app/modules/foliage/api_routes.py
@@ -2,6 +2,7 @@
 
 from . import foliage_api as api
 from flask import request, jsonify, Response
+from .helpers import calculate_liebig_balance
 from .controller import (
     FarmView,
     LotView,
@@ -236,3 +237,15 @@ api.add_url_rule(
     view_func=crop_csv_import_view,
     methods=["POST"],
 )
+
+
+@api.route("/get_balance_data")
+def get_balance_data():
+    """Return Liebig balance calculation for given objective and analysis."""
+    objective_id = request.args.get("objective_id", type=int)
+    analysis_id = request.args.get("analysis_id", type=int)
+    if not objective_id or not analysis_id:
+        return jsonify({"error": "objective_id and analysis_id are required"}), 400
+
+    data = calculate_liebig_balance(objective_id, analysis_id)
+    return jsonify(data)

--- a/project/app/modules/foliage_report/controller.py
+++ b/project/app/modules/foliage_report/controller.py
@@ -37,6 +37,7 @@ from .helpers import (
     LeafAnalysisResource,
     ReportView,
 )
+from app.modules.foliage.helpers import calculate_liebig_balance
 
 
 class RecommendationView(MethodView):
@@ -375,6 +376,13 @@ class RecommendationGenerator(MethodView):
             analysis_data_for_report.get("soil"), default=str
         )
 
+        # Liebig balance data
+        liebig_data = calculate_liebig_balance(
+            objective_id,
+            common_analysis.leaf_analysis.id,
+        )
+        liebig_data_json = json.dumps(liebig_data, default=str)
+
         # Optimal comparison from the objective
         # Necesitamos un método para formatear los datos del objetivo como optimal_levels
         # Formato esperado: {'Nutriente': {'min': X, 'max': Y, 'ideal': Z, 'unit': 'unidad'}}
@@ -405,6 +413,7 @@ class RecommendationGenerator(MethodView):
                 automatic_recommendations=recomendacion_texto,
                 text_recommendations="",
                 optimal_comparison=optimal_comparison_json,
+                minimum_law_analyses=liebig_data_json,
                 soil_analysis_details=soil_details_json,
                 foliar_analysis_details=foliar_details_json,
                 # Considerar añadir objective_id y common_analysis_ids_used si se modifica el modelo


### PR DESCRIPTION
## Summary
- compute Liebig balance and limiting nutrient in `calculate_liebig_balance`
- expose `/get_balance_data` API endpoint
- store Liebig balance data when generating recommendations

## Testing
- `black ../project/app/modules/foliage/helpers.py ../project/app/modules/foliage/api_routes.py ../project/app/modules/foliage_report/controller.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd0d91c5c832e85c6500eea3c770d