### PR TITLE
Check farm_id for get_lots

### DIFF
--- a/project/app/modules/foliage_report/api_routes.py
+++ b/project/app/modules/foliage_report/api_routes.py
@@ -64,7 +64,10 @@ def get_farms():
 def get_lots():
     claims = get_jwt()
     farm_id = request.args.get("farm_id")
-    farm = Farm.query.get_or_404(farm_id)
+    if not farm_id or not str(farm_id).isdigit():
+        return jsonify({"error": "farm_id required"}), 400
+
+    farm = Farm.query.get_or_404(int(farm_id))
 
     # Verificar si el usuario tiene acceso a esta finca
     if not check_resource_access(farm, claims):

--- a/project/app/modules/foliage_report/templates/listar_reportes.j2
+++ b/project/app/modules/foliage_report/templates/listar_reportes.j2
@@ -182,7 +182,12 @@ function loadLots(farmId) {
     
     if (farmId) {
         fetch(`{{ url_for('foliage_report_api.get_lots') }}?farm_id=${farmId}`)
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                return response.json().then(data => { throw new Error(data.error || 'Error al cargar lotes'); });
+            }
+            return response.json();
+        })
         .then(lots => {
             lots.forEach(lot => {
                 const option = document.createElement('option');
@@ -194,6 +199,9 @@ function loadLots(farmId) {
                 }
                 lotSelect.appendChild(option);
             });
+        })
+        .catch(error => {
+            console.error(error);
         });
     }
 }

--- a/project/app/modules/foliage_report/templates/solicitar_informe.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe.j2
@@ -120,8 +120,12 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('farm-select').addEventListener('change', function() {
         const farmId = this.value;
         fetch(`{{ url_for('foliage_report_api.get_lots') }}?farm_id=${farmId}`)
-        
-            .then(response => response.json())
+            .then(response => {
+                if (!response.ok) {
+                    return response.json().then(data => { throw new Error(data.error || 'Error al cargar lotes'); });
+                }
+                return response.json();
+            })
             .then(lots => {
                 const lotSelect = document.getElementById('lot-select');
                 lotSelect.innerHTML = '<option value="">Todos los lotes</option>';
@@ -131,6 +135,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     option.textContent = lot.name;
                     lotSelect.appendChild(option);
                 });
+            })
+            .catch(error => {
+                console.error(error);
             });
     });
     

--- a/project/app/modules/foliage_report/templates/solicitar_informe2.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe2.j2
@@ -237,9 +237,14 @@
             lotSelect.disabled = false; // Enable before fetch
             fetch(`{{ url_for('foliage_report_api.get_lots') }}?farm_id=${farmId}`)
                 .then(response => {
-                     if (!response.ok) throw new Error('Error al cargar lotes');
-                     return response.json();
-                 })
+                    if (!response.ok) {
+                        return response.json().then(data => {
+                            const msg = data && data.error ? data.error : 'Error al cargar lotes';
+                            throw new Error(msg);
+                        });
+                    }
+                    return response.json();
+                })
                 .then(lots => {
                     resetSelect(lotSelect, 'Seleccione un lote...');
                     lots.forEach(lot => {
@@ -255,7 +260,7 @@
                 .catch(error => {
                     console.error(error);
                     resetSelect(lotSelect, 'Error al cargar lotes');
-                    errorMessage.textContent = 'Error al cargar lotes.';
+                    errorMessage.textContent = error.message || 'Error al cargar lotes.';
                     errorMessage.classList.remove('hidden');
                 });
         });


### PR DESCRIPTION
## Summary
- validate `farm_id` in foliage report API
- surface API error messages when requesting lots in JavaScript templates

## Testing
- `make test` *(fails: project/venv/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685dd6f1e62c832eb92f63990adc57ac