### PR TITLE
Add NutrientCV model and CRUD

### DIFF
--- a/project/app/modules/foliage/api_routes.py
+++ b/project/app/modules/foliage/api_routes.py
@@ -18,6 +18,7 @@ from .controller import (
     ProductContributionView,
     ProductionView,
     ProductPriceView,
+    NutrientCVView,
     ProductView,
     SoilAnalysisView,
 )
@@ -51,6 +52,15 @@ api.add_url_rule(
 )
 api.add_url_rule(
     "/nutrients/<int:id>", view_func=nutrient_view, methods=["GET", "PUT", "DELETE"]
+)
+
+# Nutrient CV endpoints
+nutrient_cv_view = NutrientCVView.as_view("nutrient_cvs")
+api.add_url_rule(
+    "/nutrient_cvs/", view_func=nutrient_cv_view, methods=["GET", "POST", "DELETE"]
+)
+api.add_url_rule(
+    "/nutrient_cvs/<int:id>", view_func=nutrient_cv_view, methods=["GET", "PUT", "DELETE"]
 )
 
 # 👌

--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -1756,6 +1756,100 @@ class ProductPriceView(MethodView):
         }
 
 
+# Vista para coeficientes de variación de nutrientes (nutrient_cvs)
+class NutrientCVView(MethodView):
+    """Class to manage CRUD operations for nutrient CV values"""
+
+    decorators = [jwt_required()]
+
+    @check_permission(required_roles=["administrator", "reseller"])
+    def get(self, nutrient_cv_id=None):
+        if nutrient_cv_id:
+            return self._get_nutrient_cv(nutrient_cv_id)
+        return self._get_nutrient_cv_list()
+
+    @check_permission(required_roles=["administrator"])
+    def post(self):
+        data = request.get_json()
+        required_fields = ["nutrient_id", "cv"]
+        if not data or not all(k in data for k in required_fields):
+            raise BadRequest("Missing required fields")
+        return self._create_nutrient_cv(data)
+
+    @check_permission(required_roles=["administrator"])
+    def put(self, id: int):
+        data = request.get_json()
+        nutrient_cv_id = id
+        if not data or not nutrient_cv_id:
+            raise BadRequest("Missing nutrient_cv_id or data")
+        return self._update_nutrient_cv(nutrient_cv_id, data)
+
+    @check_permission(required_roles=["administrator"])
+    def delete(self, id=None):
+        nutrient_cv_id = id
+        if not nutrient_cv_id:
+            raise BadRequest("Missing nutrient_cv_id")
+        return self._delete_nutrient_cv(nutrient_cv_id)
+
+    # Helper Methods
+    def _get_nutrient_cv_list(self):
+        nutrient_cvs = NutrientCV.query.all()
+        response_data = [self._serialize_nutrient_cv(nc) for nc in nutrient_cvs]
+        json_data = json.dumps(response_data, ensure_ascii=False, indent=4)
+        return Response(json_data, status=200, mimetype="application/json")
+
+    def _get_nutrient_cv(self, nutrient_cv_id):
+        nutrient_cv = NutrientCV.query.get_or_404(nutrient_cv_id)
+        claims = get_jwt()
+        if not self._has_access(nutrient_cv, claims):
+            raise Forbidden("You do not have access to this resource")
+        response_data = self._serialize_nutrient_cv(nutrient_cv)
+        json_data = json.dumps(response_data, ensure_ascii=False, indent=4)
+        return Response(json_data, status=200, mimetype="application/json")
+
+    def _create_nutrient_cv(self, data):
+        nutrient_id = data["nutrient_id"]
+        cv = data["cv"]
+        existing = NutrientCV.query.filter_by(nutrient_id=nutrient_id).first()
+        if existing:
+            raise Conflict("CV for this nutrient already exists")
+        nutrient_cv = NutrientCV(nutrient_id=nutrient_id, cv=cv)
+        db.session.add(nutrient_cv)
+        db.session.commit()
+        response_data = self._serialize_nutrient_cv(nutrient_cv)
+        json_data = json.dumps(response_data, ensure_ascii=False, indent=4)
+        return Response(json_data, status=201, mimetype="application/json")
+
+    def _update_nutrient_cv(self, nutrient_cv_id, data):
+        nutrient_cv = NutrientCV.query.get_or_404(nutrient_cv_id)
+        if "nutrient_id" in data:
+            nutrient_cv.nutrient_id = data["nutrient_id"]
+        if "cv" in data:
+            nutrient_cv.cv = data["cv"]
+        db.session.commit()
+        response_data = self._serialize_nutrient_cv(nutrient_cv)
+        json_data = json.dumps(response_data, ensure_ascii=False, indent=4)
+        return Response(json_data, status=200, mimetype="application/json")
+
+    def _delete_nutrient_cv(self, nutrient_cv_id):
+        nutrient_cv = NutrientCV.query.get_or_404(nutrient_cv_id)
+        db.session.delete(nutrient_cv)
+        db.session.commit()
+        return jsonify({"message": "Nutrient CV deleted successfully"}), 200
+
+    def _has_access(self, nutrient_cv, claims):
+        return check_resource_access(nutrient_cv, claims)
+
+    def _serialize_nutrient_cv(self, nutrient_cv):
+        return {
+            "id": nutrient_cv.id,
+            "nutrient_id": nutrient_cv.nutrient_id,
+            "nutrient_name": nutrient_cv.nutrient.name if nutrient_cv.nutrient else None,
+            "cv": float(nutrient_cv.cv),
+            "created_at": nutrient_cv.created_at.isoformat(),
+            "updated_at": nutrient_cv.updated_at.isoformat(),
+        }
+
 # 👌# Vista para análisis comunes (common_analyses)
 class CommonAnalysisView(MethodView):
     """Clase para gestionar operaciones CRUD sobre análisis comunes."""

--- a/project/app/modules/foliage/models.py
+++ b/project/app/modules/foliage/models.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 from enum import Enum
 
 from marshmallow import Schema, ValidationError, fields, validates
@@ -272,6 +273,11 @@ class Nutrient(db.Model):
         secondary=product_contribution_nutrients,
         back_populates="nutrients",
     )
+    cv_value = db.relationship(
+        "NutrientCV",
+        uselist=False,
+        back_populates="nutrient",
+    )
 
     def __repr__(self):
         return f"<Nutrient {self.name} ({self.symbol})>"
@@ -510,6 +516,29 @@ class ProductPrice(db.Model):
 
     def __repr__(self):
         return f"<ProductPrice {self.id}>"
+
+
+class NutrientCV(db.Model):
+    """Model representing coefficient of variation for a nutrient"""
+
+    __tablename__ = "nutrient_cvs"
+
+    id = db.Column(db.Integer, primary_key=True)
+    nutrient_id = db.Column(db.Integer, db.ForeignKey("nutrients.id"), nullable=False)
+    cv = db.Column(db.Numeric(5, 2), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    nutrient = db.relationship("Nutrient", back_populates="cv_value")
+
+    __table_args__ = (
+        db.UniqueConstraint("nutrient_id", name="uq_nutrient_cv_nutrient_id"),
+    )
+
+    def __repr__(self):
+        return f"<NutrientCV {self.id} - Nutrient {self.nutrient_id}>"
 
 
 # Validación de nutrientes

--- a/project/app/modules/foliage/schemas.py
+++ b/project/app/modules/foliage/schemas.py
@@ -154,6 +154,14 @@ class ProductPriceSchema(Schema):
     updated_at = fields.DateTime(dump_only=True)
 
 
+class NutrientCVSchema(Schema):
+    id = fields.Int(dump_only=True)
+    nutrient_id = fields.Int(required=True)
+    cv = fields.Decimal(as_string=True, required=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
 class RecommendationSchema(Schema):
     id = fields.Int(dump_only=True)
     lot_id = fields.Int(required=True)

--- a/project/app/modules/foliage/templates/nutrient_cvs.j2
+++ b/project/app/modules/foliage/templates/nutrient_cvs.j2
@@ -1,0 +1,11 @@
+{% extends "layouts/crud_base.j2" %}
+{% set entity_name = "Coeficientes_variacion" %}
+{% set entity_name_lower = "coeficiente_variacion" %}
+{% set show_select_box = False %}
+{% set table_headers = ["ID", "Nutriente", "CV", "Fecha de creación", "Fecha de actualización"] %}
+{% set item_fields = ["id", "nutrient_name", "cv", "created_at", "updated_at"] %}
+{% set form_fields = {
+    'nutrient_id': {'type': 'select', 'label': 'Nutriente', 'options': nutrient_options, 'required': True, 'new_value': False},
+    'cv': {'type': 'number', 'label': 'CV', 'required': True, 'step': '0.01'}
+} %}
+{% set api_url = url_for('foliage_api.nutrient_cvs') %}

--- a/project/app/modules/foliage/web_routes.py
+++ b/project/app/modules/foliage/web_routes.py
@@ -20,6 +20,7 @@ from .controller import (
     ProductContributionView,
     ProductionView,
     ProductPriceView,
+    NutrientCVView,
     ProductView,
     SoilAnalysisView,
 )
@@ -490,6 +491,42 @@ def amd_product_prices():
             "product_prices.j2",
             items=items,
             product_options=product_options,
+            **context,
+            request=request,
+        ),
+        200,
+    )
+
+
+# --------------------------------------------------------
+# Nutrient CV
+# --------------------------------------------------------
+
+@web.route("/nutrient_cvs")
+@login_required
+def amd_nutrient_cvs():
+    """Página: Gestión de coeficientes de variación"""
+    user_id = get_jwt_identity()
+    context = {
+        "dashboard": True,
+        "title": "Gestión de CV de nutrientes",
+        "description": "Administración de coeficientes de variación por nutriente.",
+        "author": "Johnny De Castro",
+        "site_title": "Panel de Control",
+        "data_menu": get_dashboard_menu(),
+    }
+    nutrient_cv_view = NutrientCVView()
+    response = nutrient_cv_view._get_nutrient_cv_list()
+    items = response.get_json()
+    status_code = response.status_code
+    nutrient_options = {n.name: n.id for n in Nutrient.query.all()}
+    if status_code != 200:
+        return render_template("error.j2"), status_code
+    return (
+        render_template(
+            "nutrient_cvs.j2",
+            items=items,
+            nutrient_options=nutrient_options,
             **context,
             request=request,
         ),


### PR DESCRIPTION
## Summary
- add `NutrientCV` model with one-to-one relationship to `Nutrient`
- create API endpoints and web view for nutrient CV management
- expose nutrient CV form template

## Testing
- `make check` *(fails: project/venv/bin/black: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68658f00de40832eac1010e4fdef0d5e