### PR TITLE
Add CV field to nutrient model and UI

### DIFF
--- a/project/app/modules/foliage/controller.py
+++ b/project/app/modules/foliage/controller.py
@@ -792,6 +792,7 @@ class NutrientView(MethodView):
             name=data["name"],
             symbol=data["symbol"],
             unit=data["unit"],
+            cv=data.get("cv"),
         )
         db.session.add(nutrient)
         db.session.commit()
@@ -814,6 +815,8 @@ class NutrientView(MethodView):
             nutrient.symbol = data["symbol"]
         if "unit" in data:
             nutrient.unit = data["unit"]
+        if "cv" in data:
+            nutrient.cv = data["cv"]
         db.session.commit()
         response_data = self._serialize_nutrient(nutrient)
         json_data = json.dumps(response_data, ensure_ascii=False, indent=4)
@@ -880,6 +883,7 @@ class NutrientView(MethodView):
             "symbol": nutrient.symbol,
             "unit": nutrient.unit,
             "description": nutrient.description,
+            "cv": nutrient.cv,
             "created_at": nutrient.created_at.isoformat(),
             "updated_at": nutrient.updated_at.isoformat(),
         }

--- a/project/app/modules/foliage/models.py
+++ b/project/app/modules/foliage/models.py
@@ -249,6 +249,7 @@ class Nutrient(db.Model):
     unit = db.Column(db.String(20), nullable=False)
     description = db.Column(db.Text)
     category = db.Column(db.Enum(NutrientCategory))
+    cv = db.Column(db.Float)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/project/app/modules/foliage/schemas.py
+++ b/project/app/modules/foliage/schemas.py
@@ -10,6 +10,7 @@ class NutrientSchema(Schema):
     unit = fields.Str(required=True)
     org_id = fields.Int()
     description = fields.Str(allow_none=True)
+    cv = fields.Float(allow_none=True)
     created_at = fields.DateTime(dump_only=True)
     updated_at = fields.DateTime(dump_only=True)
 
@@ -82,6 +83,7 @@ class NutrientSchema(Schema):
     unit = fields.Str(required=True)
     description = fields.Str(allow_none=True)
     category = fields.Str()
+    cv = fields.Float(allow_none=True)
     created_at = fields.DateTime(dump_only=True)
     updated_at = fields.DateTime(dump_only=True)
 

--- a/project/app/modules/foliage/templates/nutrients.j2
+++ b/project/app/modules/foliage/templates/nutrients.j2
@@ -4,14 +4,19 @@
 {% set entity_name_lower = "nutriente" %}
 {% set show_select_box = True %}
 {# Mostrar la grid de ítems #}
-{% set table_headers = ["ID", "Nombre del nutriente", "Símbolo del nutriente", "Unidad del nutriente", "Descripción"] %}
-{% set item_fields = ["id", "name", "symbol", "unit", "description"] %}
+{% set table_headers = ["ID", "Nombre del nutriente", "Símbolo del nutriente", "Unidad del nutriente", "Descripción", "CV"] %}
+{% set item_fields = ["id", "name", "symbol", "unit", "description", "cv"] %}
 
 {# formulario de editar y add #}
 {% set form_fields = {
     'name': {'type': 'text', 'label': 'Nombre del nutriente', 'required': True},
     'symbol': {'type': 'text', 'label': 'Símbolo del nutriente', 'required': True},
     'unit': {'type': 'text', 'label': 'Unidad del nutriente', 'required': True},
+    'cv': {
+        'type': 'number',
+        'label': 'Coeficiente de variación',
+        'step': 'any',
+    },
 } %}
 {# entregado desde el endpoint #}
 {# api de consumo #}

--- a/project/migrations/versions/abc123_add_cv_to_nutrients.py
+++ b/project/migrations/versions/abc123_add_cv_to_nutrients.py
@@ -1,0 +1,23 @@
+"""add cv column to nutrients
+
+Revision ID: abc123
+Revises: b1d3f9c38b9c
+Create Date: 2025-06-09 07:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'abc123'
+down_revision = 'b1d3f9c38b9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('nutrients', sa.Column('cv', sa.Float(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('nutrients', 'cv')


### PR DESCRIPTION
## Summary
- add `cv` column to `Nutrient` model and Alembic migration
- expose `cv` via API create/update/serialize
- include CV in nutrient Jinja2 form and table
- update Marshmallow schemas

## Testing
- `make check` *(fails: cannot open venv)*

------
https://chatgpt.com/codex/tasks/task_e_6867210ee1dc832e8672a3f2add383ec