### PR TITLE
Show CV values in foliage analysis report

### DIFF
--- a/project/app/modules/foliage_report/api_routes.py
+++ b/project/app/modules/foliage_report/api_routes.py
@@ -217,3 +217,21 @@ def get_analyses():
         analyses.append(analysis_data)
 
     return jsonify(analyses)
+
+
+@api.route("/cv-nutrients")
+@login_required
+def get_cv_nutrients():
+    """Return coefficient of variation values stored for nutrients."""
+    lot_id = request.args.get("lot_id", type=int)
+    if not lot_id:
+        return jsonify({"error": "lot_id es requerido"}), 400
+
+    lot = Lot.query.get_or_404(lot_id)
+    claims = get_jwt()
+    if not check_resource_access(lot.farm, claims):
+        return jsonify({"error": "No tienes acceso a este lote"}), 403
+
+    nutrients = Nutrient.query.all()
+    data = {n.name: float(n.cv) if n.cv is not None else None for n in nutrients}
+    return jsonify(data)

--- a/project/app/modules/foliage_report/templates/solicitar_informe2.j2
+++ b/project/app/modules/foliage_report/templates/solicitar_informe2.j2
@@ -86,6 +86,10 @@
         <h2 class="text-lg font-semibold mb-2">Información del Análisis</h2>
         <div id="analysis-info-content" class="text-sm"></div>
     </div>
+    <div id="cv-info" class="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg shadow hidden">
+        <h2 class="text-lg font-semibold mb-2">CV por Nutriente</h2>
+        <div id="cv-info-content" class="text-sm"></div>
+    </div>
     <div id="claculate-info" class="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg shadow hidden">
         <h2 class="text-lg font-semibold mb-2">Información del Análisis</h2>
         <div id="claculate-info-content" class="text-sm"></div>
@@ -153,7 +157,10 @@
         const cropInfoContent = document.getElementById('crop-info-content');
         const analysisInfoDiv = document.getElementById('analysis-info');
         const analysisInfoContent = document.getElementById('analysis-info-content');
+        const cvInfoDiv = document.getElementById('cv-info');
+        const cvInfoContent = document.getElementById('cv-info-content');
         let analysisDataMap = {};
+        let cvData = {};
 
         // Function to clear and disable a select element
         function resetSelect(selectElement, defaultOptionText) {
@@ -218,12 +225,55 @@ function updateCropInfo(cropId) {
         });
 }
 
+        function fetchCVValues(lotId) {
+            if (!lotId) {
+                cvData = {};
+                updateCVInfo();
+                return;
+            }
+            fetch(`{{ url_for('foliage_report_api.get_cv_nutrients') }}?lot_id=${lotId}`)
+                .then(response => {
+                    if (!response.ok) throw new Error('Error al cargar CV');
+                    return response.json();
+                })
+                .then(data => {
+                    cvData = data;
+                    updateCVInfo();
+                })
+                .catch(error => {
+                    console.error(error);
+                    cvData = {};
+                    updateCVInfo();
+                });
+        }
+
+        function updateCVInfo() {
+            if (!cvData || Object.keys(cvData).length === 0) {
+                cvInfoDiv.classList.add('hidden');
+                cvInfoContent.innerHTML = '';
+                return;
+            }
+            let html = '<div class="grid grid-cols-1 md:grid-cols-13 gap-13">';
+            Object.keys(cvData).forEach(nutrient => {
+                html += `
+                    <div>
+                        <label class="block text-tiny font-medium mb-1">${nutrient}</label>
+                        <input type="text" value="${cvData[nutrient]}" disabled class="w-full border p-1 rounded dark:bg-gray-700 dark:border-gray-600">
+                    </div>
+                `;
+            });
+            html += '</div>';
+            cvInfoContent.innerHTML = html;
+            cvInfoDiv.classList.remove('hidden');
+        }
+
 
         function updateAnalysisInfo() {
             const selected = Array.from(document.querySelectorAll('#analyses-list input[name="selected_analyses"]:checked'));
             if (selected.length === 0) {
                 analysisInfoDiv.classList.add('hidden');
                 analysisInfoContent.innerHTML = '';
+                cvInfoDiv.classList.add('hidden');
                 return;
             }
             let html = '';
@@ -255,6 +305,7 @@ function updateCropInfo(cropId) {
             });
             analysisInfoContent.innerHTML = html;
             analysisInfoDiv.classList.remove('hidden');
+            updateCVInfo();
 
         }
         
@@ -290,6 +341,7 @@ function updateCropInfo(cropId) {
             selectedCropIdInput.value = '';
             updateCropInfo(null);
             updateAnalysisInfo();
+            fetchCVValues(null);
 
             if (!farmId) {
                  resetSelect(lotSelect, 'Seleccione un lote...');
@@ -334,6 +386,7 @@ function updateCropInfo(cropId) {
             selectedCropIdInput.value = cropId || '';
             updateCropInfo(cropId);
             updateAnalysisInfo();
+            fetchCVValues(lotId);
 
 
             if (!lotId) {


### PR DESCRIPTION
## Summary
- add CV display box in foliage report info page
- fetch CV values via new API route
- expose coefficient of variation endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867379c58f4832e9c2b790c0e34e434