### PR TITLE
Integrate dynamic data into foliage report view

### DIFF
--- a/project/app/modules/foliage_report/templates/ver_reporte2.j2
+++ b/project/app/modules/foliage_report/templates/ver_reporte2.j2
@@ -226,9 +226,13 @@
                             <div class="absolute inset-x-0 bottom-0 h-12 bg-green-800"></div>
                             <!-- Duelas del barril -->
                             <div class="absolute inset-0 flex justify-around">
-                                {% for nutrient in foliarChartData %}
-                                    {% set percentage = (nutrient.actual / ((nutrient.min + nutrient.max) / 2)) * 100 %}
-                                    {% set isLimiting = limitingNutrient and limitingNutrient.name == nutrient.name %}
+                                {% for nutrient_chart_item in foliarChartData %}
+                                    {% if nutrient_chart_item.min is not none and nutrient_chart_item.max is not none and nutrient_chart_item.max > nutrient_chart_item.min %}
+                                        {% set percentage_of_optimal = (nutrient_chart_item.actual / ((nutrient_chart_item.min + nutrient_chart_item.max) / 2)) * 100 %}
+                                    {% else %}
+                                        {% set percentage_of_optimal = 100 %} {# Default or handle case where min/max is not ideal #}
+                                    {% endif %}
+                                    {% set isLimiting = limitingNutrient and limitingNutrient.name == nutrient_chart_item.data_key %}
                                     <div class="relative h-full w-8 flex flex-col justify-end items-center">
                                         <div
                                             class="w-6 rounded-t-md {{ 'bg-red-500' if isLimiting else 'bg-blue-500' }}"
@@ -374,35 +378,46 @@
                                         </li>
                                     {% endif %}
                                 {% endfor %}
-                                    {% if not (analysisData.foliar|selectattr('is_deficiente', test='attr')|list|length > 0) %}
+                                    {# Check if any deficiencies were found and displayed #}
+                                    {% set has_foliar_deficiencies = false %}
+                                    {% for key, value in analysisData.foliar.items() %}
+                                        {% if key in optimalLevels.foliar and optimalLevels.foliar[key].min is not none and value is not none and value < optimalLevels.foliar[key].min %}
+                                            {% set has_foliar_deficiencies = true %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    {% if not has_foliar_deficiencies %}
                                         <li class="text-green-600 flex items-center">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 mr-2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="12 2 2 7.86 12 12"></polyline><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
-                                            No se detectaron deficiencias significativas
+                                            No se detectaron deficiencias significativas.
                                         </li>
                                     {% endif %}
-
                             </ul>
                         </div>
                         <div>
                             <h3 class="text-md font-semibold mb-2">Excesos</h3>
                             <ul class="space-y-2">
                                 {% for key, value in analysisData.foliar.items() %}
-                                    {% if key in optimalLevels.foliar and value > optimalLevels.foliar[key].max %}
+                                    {% if key in optimalLevels.foliar and optimalLevels.foliar[key].max is not none and value is not none and value > optimalLevels.foliar[key].max %}
                                         <li class="flex items-start gap-2">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-yellow-500 mt-0.5"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
                                             <div>
                                                 <span class="font-medium">{{ nutrientNames[key] or key }}:</span> {{ value }}% (Máximo recomendado: {{ optimalLevels.foliar[key].max }}%)
                                             </div>
                                         </li>
+                                    {% endif %}
+                                {% endfor %}
+                                    {% set has_foliar_excesses = false %}
+                                    {% for key, value in analysisData.foliar.items() %}
+                                        {% if key in optimalLevels.foliar and optimalLevels.foliar[key].max is not none and value is not none and value > optimalLevels.foliar[key].max %}
+                                            {% set has_foliar_excesses = true %}
                                         {% endif %}
                                     {% endfor %}
-                                    {% if not (analysisData.foliar|selectattr('is_excesivo', test='attr')|list|length > 0) %}
+                                    {% if not has_foliar_excesses %}
                                         <li class="text-green-600 flex items-center">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 mr-2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="12 2 2 7.86 12 12"></polyline><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
-                                            No se detectaron excesos significativos
+                                            No se detectaron excesos significativos.
                                         </li>
                                     {% endif %}
-
                             </ul>
                         </div>
                     </div>
@@ -529,30 +544,71 @@
                             <h3 class="text-md font-semibold mb-2">Deficiencias</h3>
                             <ul class="space-y-2">
                                 {% for key, value in analysisData.soil.items() %}
-                                    {% if key in optimalLevels.soil and key != 'ph' and key != 'textura' and value < optimalLevels.soil[key].min %}
+                                    {% if key in optimalLevels.soil and key != 'ph' and key != 'textura' and optimalLevels.soil[key].min is not none and value is not none and value < optimalLevels.soil[key].min %}
                                         <li class="flex items-start gap-2">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-red-500 mt-0.5"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
                                             <div>
                                                 <p>
-                                                    <span class="font-medium">{{ nutrientNames[key] or key }}:</span> {{ value }}%
-                                                    (Mínimo recomendado: {{ optimalLevels.soil[key].min }}%)
+                                                    <span class="font-medium">{{ nutrientNames[key] or key }}:</span> {{ value }}
+                                                    {% set unit = optimalLevels.soil[key].unit or '%' %}
+                                                    {{ unit }}
+                                                    (Mínimo recomendado: {{ optimalLevels.soil[key].min }} {{ unit }})
                                                 </p>
                                             </div>
                                         </li>
+                                    {% endif %}
+                                {% endfor %}
+                                    {% set has_soil_deficiencies = false %}
+                                    {% for key, value in analysisData.soil.items() %}
+                                        {% if key in optimalLevels.soil and key != 'ph' and key != 'textura' and optimalLevels.soil[key].min is not none and value is not none and value < optimalLevels.soil[key].min %}
+                                            {% set has_soil_deficiencies = true %}
                                         {% endif %}
                                     {% endfor %}
-                                    {% if not (analysisData.soil|selectattr('is_deficiente', test='attr')|list|length > 0) %}
+                                    {% if not has_soil_deficiencies %}
                                         <li class="text-green-600 flex items-center">
                                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 mr-2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="12 2 2 7.86 12 12"></polyline><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
-                                            No se detectaron deficiencias significativas
+                                            No se detectaron deficiencias significativas en nutrientes del suelo.
                                         </li>
                                     {% endif %}
                             </ul>
                         </div>
                         <div>
+                             <h3 class="text-md font-semibold mb-2">Excesos en Suelo</h3>
+                             <ul class="space-y-2">
+                                {% for key, value in analysisData.soil.items() %}
+                                    {% if key in optimalLevels.soil and key != 'ph' and key != 'textura' and optimalLevels.soil[key].max is not none and value is not none and value > optimalLevels.soil[key].max %}
+                                     <li class="flex items-start gap-2">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-yellow-500 mt-0.5"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+                                        <div>
+                                            <p>
+                                                <span class="font-medium">{{ nutrientNames[key] or key }}:</span> {{ value }}
+                                                {% set unit = optimalLevels.soil[key].unit or '%' %}
+                                                {{ unit }}
+                                                (Máximo recomendado: {{ optimalLevels.soil[key].max }} {{ unit }})
+                                            </p>
+                                        </div>
+                                    </li>
+                                    {% endif %}
+                                {% endfor %}
+                                {% set has_soil_excesses = false %}
+                                {% for key, value in analysisData.soil.items() %}
+                                     {% if key in optimalLevels.soil and key != 'ph' and key != 'textura' and optimalLevels.soil[key].max is not none and value is not none and value > optimalLevels.soil[key].max %}
+                                        {% set has_soil_excesses = true %}
+                                    {% endif %}
+                                {% endfor %}
+                                {% if not has_soil_excesses %}
+                                    <li class="text-green-600 flex items-center">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 mr-2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="12 2 2 7.86 12 12"></polyline><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+                                        No se detectaron excesos significativos en nutrientes del suelo.
+                                    </li>
+                                {% endif %}
+                             </ul>
+                        </div>
+                        <div>
                             {% set ph_value = analysisData.soil.get('ph') %}
+                            {% set ph_optimal_levels = optimalLevels.soil.get('ph') %}
                             <h3 class="text-md font-semibold mb-2">Problemas de pH</h3>
-                            {% if ph_value is not none and ph_value < optimalLevels.soil.ph.min %}
+                            {% if ph_value is not none and ph_optimal_levels and ph_optimal_levels.min is not none and ph_value < ph_optimal_levels.min %}
                                 <div class="flex items-start gap-2">
                                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-red-500 mt-0.5"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
                                     <div>

--- a/project/app/modules/foliage_report/web_routes.py
+++ b/project/app/modules/foliage_report/web_routes.py
@@ -109,358 +109,64 @@ def listar_reportes():
 
 @web.route("/vista_reporte/<int:report_id>")
 @jwt_required()
-# @login_required
 def vista_reporte(report_id):
-
     claims = get_jwt()
+
+    # Instanciar ReportView para llamar a su método get
+    # Esto simula una llamada interna al endpoint de la API.
+    # Necesitamos pasar el token JWT de alguna manera si ReportView.get lo requiere
+    # y no lo puede obtener directamente del contexto de la solicitud actual
+    # de la misma forma que lo haría si fuera llamado externamente.
+    # Sin embargo, como ReportView usa @jwt_required(), y esta ruta también lo usa,
+    # el contexto de JWT debería estar disponible.
+
+    report_view_instance = ReportView()
+
+    try:
+        # Llamar al método get de ReportView con el report_id
+        # El método get de ReportView devuelve un objeto Flask Response.
+        # Necesitamos obtener el JSON de ese objeto.
+        response_obj = report_view_instance.get(id=report_id)
+
+        if response_obj.status_code == 200:
+            report_data = response_obj.get_json()
+        elif response_obj.status_code == 404:
+             current_app.logger.error(f"Reporte con ID {report_id} no encontrado.")
+             # Renderizar una plantilla de error o redirigir
+             return render_template("default/404.j2", error_message=f"Reporte con ID {report_id} no encontrado."), 404
+        else:
+            current_app.logger.error(f"Error obteniendo reporte {report_id}: {response_obj.status_code} - {response_obj.get_data(as_text=True)}")
+            return render_template("default/500.j2", error_message="Error al cargar el reporte."), response_obj.status_code
+
+    except Exception as e:
+        current_app.logger.error(f"Excepción al obtener datos del reporte {report_id}: {e}", exc_info=True)
+        return render_template("default/500.j2", error_message="Error interno al procesar la solicitud del reporte."), 500
+
+    # Contexto base para el template
     context = {
         "dashboard": True,
-        "title": "Ver Informe de Análisis",
-        "description": "Detalles del informe.",
-        "author": "Johnny De Castro",
+        "title": f"Ver Informe: {report_data.get('title', 'Detalle')}",
+        "description": "Detalles del informe de análisis.",
+        "author": "Sistema TecnoAgro", # O tomar de report_data si está disponible
         "site_title": "Ver Informe",
         "data_menu": get_dashboard_menu(),
+        "request": request, # Pasar el objeto request al template
     }
     
-    return render_template(
-        "ver_reporte2.j2",  # Changed template
-        **context,
-    )
-
-
-@web.route("/vista_report")
-@login_required
-def vista_report():
-    context = {
-        "dashboard": True,
-        "title": "Dashboard TecnoAgro",
-        "description": "Panel de control.",
-        "author": "Johnny De Castro",
-        "site_title": "Panel de Control",
-        "og_image": "/img/og-image.jpg",
-        "twitter_image": "/img/twitter-image.jpg",
-        "data_menu": get_dashboard_menu(),
-    }
-
-    analysisData = {
-        "common": {
-            "id": 3,
-            "fechaAnalisis": "2025-03-26",
-            "finca": "El nuevo rocío",
-            "lote": "Lote 1",
-            "proteinas": 6.0,
-            "descanso": 5.0,
-            "diasDescanso": 5,
-            "mes": 5,
-        },
-        "foliar": {
-            "id": 1,
-            "nitrogeno": 2.5,
-            "fosforo": 0.3,
-            "potasio": 1.8,
-            "calcio": 1.2,
-            "magnesio": 0.4,
-            "azufre": 0.2,
-            "hierro": 85,
-            "manganeso": 45,
-            "zinc": 18,
-            "cobre": 6,
-            "boro": 25,
-        },
-        "soil": {
-            "id": 1,
-            "ph": 6.5,
-            "materiaOrganica": 3.2,
-            "nitrogeno": 0.15,
-            "fosforo": 12,
-            "potasio": 180,
-            "calcio": 1200,
-            "magnesio": 180,
-            "azufre": 15,
-            "textura": "Franco-arcillosa",
-            "cic": 15.2,
-        },
-    }
-
-    optimalLevels = {
-        "foliar": {
-            "nitrogeno": {"min": 2.8, "max": 3.5},
-            "fosforo": {"min": 0.2, "max": 0.4},
-            "potasio": {"min": 2.0, "max": 3.0},
-            "calcio": {"min": 1.0, "max": 2.0},
-            "magnesio": {"min": 0.3, "max": 0.6},
-            "azufre": {"min": 0.2, "max": 0.4},
-            "hierro": {"min": 50, "max": 150},
-            "manganeso": {"min": 25, "max": 100},
-            "zinc": {"min": 20, "max": 50},
-            "cobre": {"min": 5, "max": 15},
-            "boro": {"min": 20, "max": 50},
-        },
-        "soil": {
-            "ph": {"min": 6.0, "max": 7.0},
-            "materiaOrganica": {"min": 3.0, "max": 5.0},
-            "nitrogeno": {"min": 0.15, "max": 0.25},
-            "fosforo": {"min": 15, "max": 30},
-            "potasio": {"min": 150, "max": 250},
-            "calcio": {"min": 1000, "max": 2000},
-            "magnesio": {"min": 150, "max": 300},
-            "azufre": {"min": 10, "max": 20},
-            "cic": {"min": 12, "max": 25},
-        },
-    }
-
-    foliarChartData = [
-        {
-            "name": "N",
-            "actual": analysisData["foliar"]["nitrogeno"],
-            "min": optimalLevels["foliar"]["nitrogeno"]["min"],
-            "max": optimalLevels["foliar"]["nitrogeno"]["max"],
-        },
-        {
-            "name": "P",
-            "actual": analysisData["foliar"]["fosforo"],
-            "min": optimalLevels["foliar"]["fosforo"]["min"],
-            "max": optimalLevels["foliar"]["fosforo"]["max"],
-        },
-        {
-            "name": "K",
-            "actual": analysisData["foliar"]["potasio"],
-            "min": optimalLevels["foliar"]["potasio"]["min"],
-            "max": optimalLevels["foliar"]["potasio"]["max"],
-        },
-        {
-            "name": "Ca",
-            "actual": analysisData["foliar"]["calcio"],
-            "min": optimalLevels["foliar"]["calcio"]["min"],
-            "max": optimalLevels["foliar"]["calcio"]["max"],
-        },
-        {
-            "name": "Mg",
-            "actual": analysisData["foliar"]["magnesio"],
-            "min": optimalLevels["foliar"]["magnesio"]["min"],
-            "max": optimalLevels["foliar"]["magnesio"]["max"],
-        },
-        {
-            "name": "S",
-            "actual": analysisData["foliar"]["azufre"],
-            "min": optimalLevels["foliar"]["azufre"]["min"],
-            "max": optimalLevels["foliar"]["azufre"]["max"],
-        },
-    ]
-
-    soilChartData = [
-        {
-            "name": "pH",
-            "actual": analysisData["soil"]["ph"],
-            "min": optimalLevels["soil"]["ph"]["min"],
-            "max": optimalLevels["soil"]["ph"]["max"],
-            "unit": "",
-        },
-        {
-            "name": "M.O.",
-            "actual": analysisData["soil"]["materiaOrganica"],
-            "min": optimalLevels["soil"]["materiaOrganica"]["min"],
-            "max": optimalLevels["soil"]["materiaOrganica"]["max"],
-            "unit": "%",
-        },
-        {
-            "name": "N",
-            "actual": analysisData["soil"]["nitrogeno"],
-            "min": optimalLevels["soil"]["nitrogeno"]["min"],
-            "max": optimalLevels["soil"]["nitrogeno"]["max"],
-            "unit": "%",
-        },
-        {
-            "name": "P",
-            "actual": analysisData["soil"]["fosforo"],
-            "min": optimalLevels["soil"]["fosforo"]["min"],
-            "max": optimalLevels["soil"]["fosforo"]["max"],
-            "unit": "ppm",
-        },
-        {
-            "name": "K",
-            "actual": analysisData["soil"]["potasio"],
-            "min": optimalLevels["soil"]["potasio"]["min"],
-            "max": optimalLevels["soil"]["potasio"]["max"],
-            "unit": "ppm",
-        },
-        {
-            "name": "CIC",
-            "actual": analysisData["soil"]["cic"],
-            "min": optimalLevels["soil"]["cic"]["min"],
-            "max": optimalLevels["soil"]["cic"]["max"],
-            "unit": "meq/100g",
-        },
-    ]
-
-    historicalData = [
-        {"fecha": "Ene 2025", "nitrogeno": 2.3, "fosforo": 0.25, "potasio": 1.5},
-        {"fecha": "Feb 2025", "nitrogeno": 2.4, "fosforo": 0.28, "potasio": 1.6},
-        {"fecha": "Mar 2025", "nitrogeno": 2.5, "fosforo": 0.3, "potasio": 1.8},
-    ]
-
-    nutrientNames = {
-        "nitrogeno": "Nitrógeno",
-        "fosforo": "Fósforo",
-        "potasio": "Potasio",
-        "calcio": "Calcio",
-        "magnesio": "Magnesio",
-        "azufre": "Azufre",
-        "hierro": "Hierro",
-        "manganeso": "Manganeso",
-        "zinc": "Zinc",
-        "cobre": "Cobre",
-        "boro": "Boro",
-        "ph": "pH",
-        "materiaOrganica": "Materia Orgánica",
-        "cic": "CIC",
-    }
-
-    def getNutrientStatus(actual, min, max):
-        if actual < min:
-            return "deficiente"
-        if actual > max:
-            return "excesivo"
-        return "óptimo"
-
-    def getStatusColor(status):
-        match status:
-            case "deficiente":
-                return "text-red-500"
-            case "excesivo":
-                return "text-yellow-500"
-            case "óptimo":
-                return "text-green-500"
-            case _:
-                return ""
-
-    def getStatusIcon(status):
-        match status:
-            case "deficiente":
-                return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-red-500"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>'
-            case "excesivo":
-                return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-yellow-500"><polygon points="7.86 2 16.14 2 22 7.86 22 16.14 16.14 22 7.86 22 2 16.14 2 7.86 7.86 2"></polygon><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>'
-            case "óptimo":
-                return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4 text-green-500"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="12 2 2 7.86 12 12"></polyline><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>'
-            case _:
-                return ""
-
-    def findLimitingNutrient():
-        limitingNutrient = None
-        lowestPercentage = 100
-
-        for nutrient, value in analysisData["foliar"].items():
-            if nutrient in optimalLevels["foliar"]:
-                min_value = optimalLevels["foliar"][nutrient]["min"]
-                max_value = optimalLevels["foliar"][nutrient]["max"]
-                optimalMid = (min_value + max_value) / 2
-                percentage = (value / optimalMid) * 100
-                if percentage < lowestPercentage and percentage < 90:
-                    lowestPercentage = percentage
-                    limitingNutrient = {
-                        "name": nutrient,
-                        "value": value,
-                        "optimal": optimalMid,
-                        "percentage": percentage,
-                        "type": "foliar",
-                    }
-
-        for nutrient, value in analysisData["soil"].items():
-            if nutrient in optimalLevels["soil"] and nutrient != "ph":
-                min_value = optimalLevels["soil"][nutrient]["min"]
-                max_value = optimalLevels["soil"][nutrient]["max"]
-                optimalMid = (min_value + max_value) / 2
-                percentage = (value / optimalMid) * 100
-                if percentage < lowestPercentage and percentage < 90:
-                    lowestPercentage = percentage
-                    limitingNutrient = {
-                        "name": nutrient,
-                        "value": value,
-                        "optimal": optimalMid,
-                        "percentage": percentage,
-                        "type": "soil",
-                    }
-
-        return limitingNutrient
-
-    def generateRecommendations():
-        recommendations = []
-
-        limitingNutrient = findLimitingNutrient()
-
-        if limitingNutrient:
-            nutrientName = (
-                nutrientNames[limitingNutrient["name"]] or limitingNutrient["name"]
-            )
-            recommendations.append(
-                {
-                    "title": f"Corregir deficiencia de {nutrientName}",
-                    "description": f"El {nutrientName} es el nutriente limitante según la Ley de Liebig. Está al limitingNutrient['percentage']% del nivel óptimo.",
-                    "priority": "alta",
-                    "action": (
-                        "Aplicar fertilizante foliar rico en {nutrientName}"
-                        if limitingNutrient["type"] == "foliar"
-                        else f"Incorporar {nutrientName} al suelo mediante fertilización"
-                    ),
-                }
-            )
-
-        phStatus = getNutrientStatus(
-            analysisData["soil"]["ph"],
-            optimalLevels["soil"]["ph"]["min"],
-            optimalLevels["soil"]["ph"]["max"],
-        )
-        if phStatus != "óptimo":
-            recommendations.append(
-                {
-                    "title": (
-                        "Corregir acidez del suelo"
-                        if phStatus == "deficiente"
-                        else "Reducir alcalinidad del suelo"
-                    ),
-                    "description": f"El pH actual ({analysisData['soil']['ph']}) está {'por debajo' if phStatus == 'deficiente' else 'por encima'} del rango óptimo.",
-                    "priority": "media",
-                    "action": (
-                        "Aplicar cal agrícola para elevar el pH"
-                        if phStatus == "deficiente"
-                        else "Aplicar azufre elemental o materia orgánica para reducir el pH"
-                    ),
-                }
-            )
-
-        moStatus = getNutrientStatus(
-            analysisData["soil"]["materiaOrganica"],
-            optimalLevels["soil"]["materiaOrganica"]["min"],
-            optimalLevels["soil"]["materiaOrganica"]["max"],
-        )
-        if moStatus == "deficiente":
-            recommendations.append(
-                {
-                    "title": "Aumentar materia orgánica",
-                    "description": f"El nivel de materia orgánica ({analysisData['soil']['materiaOrganica']}%) está por debajo del óptimo.",
-                    "priority": "media",
-                    "action": "Incorporar compost, estiércol bien descompuesto o abonos verdes",
-                }
-            )
-
-        return recommendations
-
-    limitingNutrient = findLimitingNutrient()
-    recommendations = generateRecommendations()
+    # Combinar el contexto base con los datos del reporte.
+    # Las claves en report_data (analysisData, optimalLevels, etc.) estarán disponibles directamente.
+    context.update(report_data)
 
     return render_template(
         "ver_reporte2.j2",
-        **context,
-        request=request,
-        analysisData=analysisData,
-        optimalLevels=optimalLevels,
-        foliarChartData=foliarChartData,
-        soilChartData=soilChartData,
-        historicalData=historicalData,
-        nutrientNames=nutrientNames,
-        limitingNutrient=limitingNutrient,
-        recommendations=recommendations,
+        **context
     )
+
+# Eliminamos la ruta /vista_report ya que /vista_reporte/<id> la reemplaza con datos reales
+# @web.route("/vista_report")
+# @login_required
+# def vista_report():
+#     ... (código eliminado) ...
 
 
 @web.route("/solicitar_informe")


### PR DESCRIPTION
- Modified ReportView.get to gather all necessary data for ver_reporte2.j2, including analysis data, optimal levels, chart data, historical trends, limiting nutrient information, and recommendations.
- Updated the web route vista_reporte to fetch data by calling ReportView.get internally and pass it to the template.
- Eliminated the old vista_report route that used hardcoded data.
- Adjusted the ver_reporte2.j2 template to correctly consume the dynamic data provided by the updated ReportView, including logic for displaying deficiencies/excesses and ensuring chart data is correctly processed.
- Added data_key to chart items for more robust comparisons in the template (e.g., for Liebig's barrel).